### PR TITLE
refactor!: :recycle: remove boot init call, change publisherToken prop name

### DIFF
--- a/src/components/ui/AppchargeCheckout/AppchargeCheckout.vue
+++ b/src/components/ui/AppchargeCheckout/AppchargeCheckout.vue
@@ -1,5 +1,6 @@
 <template>
   <iframe
+    v-if="checkoutToken"
     :src="url"
     class="checkout-iframe"
     title="checkout"
@@ -14,21 +15,14 @@ import { defineComponent, PropType } from "vue";
 import packageInfo from "../../../../package.json";
 import { EFEEvent, EventParams, FEMessage } from "./types";
 
-const sendIframeMessage = (
-  iframe: HTMLIFrameElement,
-  message: FEMessage
-): void => {
-  iframe.contentWindow?.postMessage(message, "*");
-};
-
 export default defineComponent({
   name: "AppchargeCheckout",
   props: {
     checkoutUrl: String,
     sessionToken: String,
-    publisherToken: {
+    checkoutToken: {
       type: String,
-      required: false,
+      required: true,
     },
     onClose: {
       type: Function as PropType<(params: Partial<EventParams>) => void>,
@@ -97,20 +91,18 @@ export default defineComponent({
       }
     },
     handleLoad() {
-      this.$refs.iframeRef &&
-        sendIframeMessage(this.$refs.iframeRef as HTMLIFrameElement, {
-          event: EFEEvent.APPCHARGE_THEME,
-          params:
-            localStorage.getItem("ac_co_theme") &&
-            JSON.parse(localStorage.getItem("ac_co_theme") || "null"),
-        });
       if (typeof this.onInitialLoad === "function") {
         this.onInitialLoad();
       }
     },
   },
   mounted() {
-    const queryParams = `sdk-version=vue-${packageInfo.version}&publisher-token=${this.publisherToken || ''}`;
+    if (!this.checkoutToken) {
+      throw Error(
+        "checkoutToken prop is missing in AppchargeCheckout component"
+      );
+    }
+    const queryParams = `sdk-version=vue-${packageInfo.version}&checkout-token=${this.checkoutToken || ''}`;
     this.url = `${this.checkoutUrl}/${this.sessionToken}?${queryParams}`;
     window.addEventListener("message", this.eventHandler);
     document.head.insertAdjacentHTML(

--- a/src/components/ui/AppchargeCheckoutInit/AppchargeCheckoutInit.vue
+++ b/src/components/ui/AppchargeCheckoutInit/AppchargeCheckoutInit.vue
@@ -1,6 +1,6 @@
 <template>
   <iframe
-    :src="`https://checkout-v2${$data.env}.appcharge.com/handshake`"
+    :src="`https://checkout-v2${$data.env}.appcharge.com/handshake?checkout-token=${$props.checkoutToken}`"
     class="iframe-transparent"
     title="checkout-transparent"
     style="
@@ -28,9 +28,9 @@ export default defineComponent({
       type: String,
       default: "sandbox",
     },
-    publisherToken: {
+    checkoutToken: {
       type: String,
-      default: "",
+      required: true
     },
   },
   data() {
@@ -38,34 +38,12 @@ export default defineComponent({
       env: this.environment === "prod" ? "" : `-${this.environment}`,
     };
   },
-  mounted() {
-    this.fetchAppchargeData();
-  },
-  methods: {
-    fetchAppchargeData() {
-      const apiUrl = `https://api${this.env}.appcharge.com/checkout/v1/${this.domain}/boot`;
-
-      fetch(apiUrl, {
-        headers: {
-          "x-checkout-token": this.publisherToken || "",
-        },
-      })
-        .then((res) => res.json())
-        .then((data) => {
-          localStorage.setItem(
-            "ac_co_theme",
-            JSON.stringify({ theme: data?.theme, pks: data?.pks })
-          );
-        })
-        .catch((err) => {
-          localStorage.removeItem("ac_co_theme");
-        });
-    },
-  },
-  watch: {
-    domain: "fetchAppchargeData",
-    env: "fetchAppchargeData",
-    publisherToken: "fetchAppchargeData",
+  created() {
+    if (!this.checkoutToken) {
+      throw Error(
+        "checkoutToken prop is missing in AppchargeCheckoutInit component"
+      );
+    }
   },
 });
 </script>


### PR DESCRIPTION
BREAKING CHANGE: publisherToken prop renamed to checkoutToken and is now mandatory